### PR TITLE
Fixed shared builder among abstract/parent class

### DIFF
--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -69,6 +69,15 @@ export default class Builder<ResultType extends BuildableResource<ResultType>> i
 	}
 
 	/**
+	 * Update base object of current builder and instantiates the given class thanks to a {@link ResourceFactory}.
+	 *
+	 * @param ctor The class that needs to be instantiated.
+	 */
+	public updateBaseObject(ctor: ResourceFactory<ResultType>) {
+		this.baseObject = new ctor();
+	}
+
+	/**
 	 * Add an ignore directive for one or more paths.
 	 * 
 	 * @param paths The object paths to ignore when instantiating.

--- a/src/contracts/BuildableResource.ts
+++ b/src/contracts/BuildableResource.ts
@@ -1,5 +1,6 @@
 import Builder from "@/Builder";
 import JSONConvertible from "@/contracts/JSONConvertible";
+import cloneDeep from "lodash.clonedeep";
 
 /**
  * Defines an object that can be automatically built from JSON data.
@@ -23,8 +24,12 @@ export default abstract class BuildableResource<Type extends BuildableResource<T
 	public get build(): Builder<this> {
 		const c = (this as unknown as Type).constructor.prototype.constructor;
 
-		if (this.builder && !this.builder.isUsingClass(c)) {
+		if (!Object.getOwnPropertyDescriptor(this, 'builder') && this.builder) {
+			this.builder = cloneDeep(this.builder) as Builder<this>;
+
+			if (!this.builder.isUsingClass(c)) {
 			this.builder.updateBaseObject(c);
+			}
 		} else if (!this.builder) {
 			this.builder = new Builder<this>(c);
 		}

--- a/src/contracts/BuildableResource.ts
+++ b/src/contracts/BuildableResource.ts
@@ -23,7 +23,11 @@ export default abstract class BuildableResource<Type extends BuildableResource<T
 	public get build(): Builder<this> {
 		const c = (this as unknown as Type).constructor.prototype.constructor;
 
-		this.builder = this.builder?.isUsingClass(c) ? this.builder : new Builder<this>(c);
+		if (this.builder && !this.builder.isUsingClass(c)) {
+			this.builder.updateBaseObject(c);
+		} else if (!this.builder) {
+			this.builder = new Builder<this>(c);
+		}
 
 		return this.builder;
 	}

--- a/src/contracts/BuildableResource.ts
+++ b/src/contracts/BuildableResource.ts
@@ -28,7 +28,7 @@ export default abstract class BuildableResource<Type extends BuildableResource<T
 			this.builder = cloneDeep(this.builder) as Builder<this>;
 
 			if (!this.builder.isUsingClass(c)) {
-			this.builder.updateBaseObject(c);
+				this.builder.updateBaseObject(c);
 			}
 		} else if (!this.builder) {
 			this.builder = new Builder<this>(c);

--- a/tests/Inheritance.test.ts
+++ b/tests/Inheritance.test.ts
@@ -29,6 +29,13 @@ class ChildClassWithOtherTransform extends ParentClass {
 	public isChildClass = () => true;
 }
 
+class DeepClassWithWeirdTransform extends ChildClassWithOtherTransform {
+	@Transform((value) => +value + 50)
+	public id: number = 0;
+
+	public isChildClass = () => true;
+}
+
 describe('It uses the child class', () => {
 	test('when using the builder.', () => {
 		const instance = new Builder(ChildClass).fromJSON({
@@ -89,5 +96,15 @@ describe('It compose with the parent class', () => {
 
 		expect(instance.name).toStrictEqual('THIS IS MY NAME');
 		expect(instance.id).toStrictEqual(42);
+	})
+
+	test('when extending another subclass and overriding decorator.', () => {
+		const instance = new DeepClassWithWeirdTransform().fromJSON({
+			id: '42',
+			name: 'This is my name'
+		});
+
+		expect(instance.name).toStrictEqual('THIS IS MY NAME');
+		expect(instance.id).toStrictEqual(92);
 	})
 })

--- a/tests/Inheritance.test.ts
+++ b/tests/Inheritance.test.ts
@@ -15,6 +15,20 @@ class ChildClass extends ParentClass {
 	public isChildClass = () => true;
 }
 
+class ChildClassOverrideTransform extends ParentClass {
+	@Transform(() => 'transformed')
+	public name: string = '';
+
+	public isChildClass = () => true;
+}
+
+class ChildClassWithOtherTransform extends ParentClass {
+	@Transform((value) => +value)
+	public id: number = 0;
+
+	public isChildClass = () => true;
+}
+
 describe('It uses the child class', () => {
 	test('when using the builder.', () => {
 		const instance = new Builder(ChildClass).fromJSON({
@@ -48,5 +62,27 @@ describe('It uses the child class', () => {
 			sure it instantiated the child.
 		*/
 		expect(instance.isChildClass()).toBeTruthy();
+
+		expect(instance.name).toStrictEqual('THIS IS MY NAME');
 	});
 });
+
+describe('It compose with the parent class', () => {
+	test('when overriding parent class decorator.', () => {
+		const instance = new ChildClassOverrideTransform().fromJSON({
+			name: 'This is my name'
+		});
+
+		expect(instance.name).toStrictEqual('transformed');
+	})
+
+	test('when composing parent class decorator and child class decorator.', () => {
+		const instance = new ChildClassWithOtherTransform().fromJSON({
+			id: '42',
+			name: 'This is my name'
+		});
+
+		expect(instance.name).toStrictEqual('THIS IS MY NAME');
+		expect(instance.id).toStrictEqual(42);
+	})
+})

--- a/tests/Inheritance.test.ts
+++ b/tests/Inheritance.test.ts
@@ -69,11 +69,16 @@ describe('It uses the child class', () => {
 
 describe('It compose with the parent class', () => {
 	test('when overriding parent class decorator.', () => {
-		const instance = new ChildClassOverrideTransform().fromJSON({
+		const instanceWithOverride = new ChildClassOverrideTransform().fromJSON({
 			name: 'This is my name'
 		});
 
-		expect(instance.name).toStrictEqual('transformed');
+		const instanceWithoutOverride = new ChildClass().fromJSON({
+			name: 'This is my name'
+		});
+
+		expect(instanceWithOverride.name).toStrictEqual('transformed');
+		expect(instanceWithoutOverride.name).toStrictEqual('THIS IS MY NAME');
 	})
 
 	test('when composing parent class decorator and child class decorator.', () => {


### PR DESCRIPTION
> **Note**
> Should be merged before https://github.com/sinisimattia/tapi/pull/5

I can create a whole new standalone PR if needed (I created this branch from yours), this PR just add some fixes and tests on top of yours 🙂

It took me quite a while to understand that decorators directly modify the prototype and not the instance of a class, so the builder is initialized on the prototype of the parent/abstract class, which has the effect of sharing this builder with all the classes that extend it.

Case study:
- A parent class defines a transform decorator on the `name` property
- A subclass overrides this decorator on this same property
- Result: the decorator is updated on the prototype of the parent class because they share the same builder, so other subclasses will also be overriden

My fix is quite simple, I just have trouble with inheritance in JS which is quite different from other languages. If the `builder` property is not defined on the instance of the current class, but it is found via inheritance, I clone this builder in order to get the same parameters, and if needed I update the base object at the same time.

I implemented a test to detect this case (`when overriding parent class decorator.`) and another test to check if it is possible to compose decorators on the parent class and on the child class.

I obviously built and tested on my personal project and now everything works (inheritance, decorator override...)

Don't hesitate to give me feedback, thanks again for your time 👨‍💻